### PR TITLE
Force all profile requests to one thread.

### DIFF
--- a/src/main/java/net/rainbowcode/jpixelface/profile/ProfileFuture.java
+++ b/src/main/java/net/rainbowcode/jpixelface/profile/ProfileFuture.java
@@ -1,0 +1,70 @@
+package net.rainbowcode.jpixelface.profile;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+public class ProfileFuture implements Future<Profile>
+{
+    private boolean done = false;
+    private Profile profile = null;
+    private final ProfileType type;
+    private final String id;
+
+    public ProfileFuture(ProfileType type, String id)
+    {
+        this.type = type;
+        this.id = id;
+    }
+
+    public void setDone(boolean done)
+    {
+        this.done = done;
+    }
+
+    public void setProfile(Profile profile)
+    {
+        this.profile = profile;
+    }
+
+    @Override
+    public boolean cancel(boolean mayInterruptIfRunning)
+    {
+        return false;
+    }
+
+    @Override
+    public boolean isCancelled()
+    {
+        return false;
+    }
+
+    @Override
+    public boolean isDone()
+    {
+        return done;
+    }
+
+    @Override
+    public Profile get() throws InterruptedException, ExecutionException
+    {
+        return profile;
+    }
+
+    @Override
+    public Profile get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException
+    {
+        return profile;
+    }
+
+    public ProfileType getType()
+    {
+        return type;
+    }
+
+    public String getId()
+    {
+        return id;
+    }
+}

--- a/src/main/java/net/rainbowcode/jpixelface/profile/ProfileRequestThread.java
+++ b/src/main/java/net/rainbowcode/jpixelface/profile/ProfileRequestThread.java
@@ -1,0 +1,79 @@
+package net.rainbowcode.jpixelface.profile;
+
+import net.rainbowcode.jpixelface.StringUtil;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.UUID;
+
+public class ProfileRequestThread extends Thread implements Runnable
+{
+    Queue<ProfileFuture> futureQueue = new LinkedList<>();
+    private final Logger log = LogManager.getLogger();
+
+    @Override
+    public void run()
+    {
+        while (true)
+        {
+            if (!futureQueue.isEmpty())
+            {
+                for (ProfileFuture future : futureQueue)
+                {
+                    log.info("Processing profile request: Type: " + future.getType().name() + ", id: " + future.getId());
+                    if (future.getType().equals(ProfileType.NAME))
+                    {
+                        Profile profileFromName = ProfileManager.getProfileFromName(future.getId());
+                        future.setProfile(profileFromName);
+                        future.setDone(true);
+                    }
+                    else if (future.getType().equals(ProfileType.MOJANGUUID))
+                    {
+                        Profile profileFromUUID = ProfileManager.getProfileFromUUID(UUID.fromString(StringUtil.addDashes(future.getId())));
+                        future.setProfile(profileFromUUID);
+                        future.setDone(true);
+                    }
+                    else if (future.getType().equals(ProfileType.UUID))
+                    {
+                        Profile profileFromUUID = ProfileManager.getProfileFromUUID(UUID.fromString(future.getId()));
+                        future.setProfile(profileFromUUID);
+                        future.setDone(true);
+                    }
+                    log.info("Done processing profile request: Type: " + future.getType().name() + ", id: " + future.getId());
+                }
+                futureQueue.removeIf(ProfileFuture::isDone);
+            }
+            try
+            {
+                sleep(1);
+            }
+            catch (InterruptedException e)
+            {
+                e.printStackTrace();
+            }
+        }
+    }
+
+    public ProfileFuture getProfileByName(String name)
+    {
+        ProfileFuture future = new ProfileFuture(ProfileType.NAME, name);
+        futureQueue.add(future);
+        return future;
+    }
+
+    public ProfileFuture getProfileByMojangID(String id)
+    {
+        ProfileFuture future = new ProfileFuture(ProfileType.MOJANGUUID, id);
+        futureQueue.add(future);
+        return future;
+    }
+
+    public ProfileFuture getProfileByUUID(String id)
+    {
+        ProfileFuture future = new ProfileFuture(ProfileType.UUID, id);
+        futureQueue.add(future);
+        return future;
+    }
+}

--- a/src/main/java/net/rainbowcode/jpixelface/profile/ProfileType.java
+++ b/src/main/java/net/rainbowcode/jpixelface/profile/ProfileType.java
@@ -1,0 +1,8 @@
+package net.rainbowcode.jpixelface.profile;
+
+public enum ProfileType
+{
+    UUID,
+    MOJANGUUID,
+    NAME
+}


### PR DESCRIPTION
This fixes a race condition in which 2 or more requests come in at the same time and get processed simultaneously causing us to get temp banned by Mojang.